### PR TITLE
fix param name in managed ssh session

### DIFF
--- a/abst/bastion_support/oci_bastion.py
+++ b/abst/bastion_support/oci_bastion.py
@@ -408,7 +408,7 @@ class Bastion:
                                                                target_resource_details=oci.bastion.models.CreateManagedSshSessionTargetResourceDetails(
                                                                    session_type="MANAGED_SSH",
                                                                    target_resource_id=resource_id,
-                                                                   target_os_username=os_username),
+                                                                   target_resource_operating_system_user_name=os_username),
                                                                key_details=oci.bastion.models.PublicKeyDetails(
                                                                    public_key_content=public_key),
                                                                display_name=name,


### PR DESCRIPTION
based on https://docs.oracle.com/en-us/iaas/tools/python/2.103.0/api/bastion/models/oci.bastion.models.CreateManagedSshSessionTargetResourceDetails.html#oci.bastion.models.CreateManagedSshSessionTargetResourceDetails.target_resource_operating_system_user_name